### PR TITLE
minor: handle kwards in dem 

### DIFF
--- a/Samplers.py
+++ b/Samplers.py
@@ -260,7 +260,7 @@ class MaternClusterPointSampler(BaseSampler):
             coords.append(bounds_ext[i,0] + (bounds_ext[i,1] - bounds_ext[i,0]) * self._rng.uniform(0, 1, num_points_parent))
         return np.stack(coords).T
     
-    def getParentsImage(self, bounds, area=None): 
+    def getParentsImage(self, bounds, area=None, **kwargs): 
         if self._sampler_cfg.warp is not None:
             bounds_ext = (np.array(bounds).T*np.array(self._sampler_cfg.warp)).T
         else:
@@ -270,7 +270,8 @@ class MaternClusterPointSampler(BaseSampler):
         bounds_ext[:,1] += self._sampler_cfg.cluster_radius
         if area is None:
             area_ext = np.prod(bounds_ext[:,1] - bounds_ext[:,0])
-            area_ext = area_ext * np.sum(self.mask) / self.mask.flatten().shape[0] 
+            if kwargs.get("use_mask_area", True):
+                area_ext = area_ext * np.sum(self.mask) / self.mask.flatten().shape[0] 
         else:
             area_ext = area
         
@@ -374,7 +375,7 @@ class MaternClusterPointSampler(BaseSampler):
         if self._sampler_cfg.inherit_parents and len(parents):
             self.parents_coords = parents
         else:
-            self.parents_coords = self.getParentsImage(bounds, area=area)
+            self.parents_coords = self.getParentsImage(bounds, area=area, **kwargs)
         points = self.getDaughtersImage(self.parents_coords, bounds)
         return points
 
@@ -524,7 +525,7 @@ class ThomasClusterSampler(BaseSampler):
         bounds_ext[:,1] += self._sampler_cfg.sigma*6
         if area is None:
             area_ext = np.prod(bounds_ext[:,1] - bounds_ext[:,0])
-            if kwargs["use_mask_area"]:
+            if kwargs.get("use_mask_area", True):
                 area_ext = area_ext * np.sum(self.mask) / self.mask.flatten().shape[0] 
         else:
             area_ext = area


### PR DESCRIPTION
Fix MaternClusterPointSampler getParentsImage to safely handle use_mask_area kwarg

Apply the same fix as ThomasClusterSampler: use kwargs.get('use_mask_area', True) instead of unconditionally applying mask area adjustment